### PR TITLE
Adding Reactiflux & ReasonML (Discord Channels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 <li><a href="https://pythondev.slack.com/messages/C07EFBK3R/">Python developers</a></li>
 <li><a href="https://www.reactiflux.com/">Reactiflux</a></li>
 <li><a href="https://reactjsnews.slack.com/messages/C044HMK8N/">ReactJS</a></li>
+<li><a href="https://discordapp.com/invite/reasonml">ReasonML</a></li>
 <li><a href="https://rubydevelopers.slack.com/">Ruby Developers</a></li>
 <li><a href="https://rubyonrails-link.slack.com/">Ruby on Rails</a></li>
 <li><a href="https://scotchio.slack.com/messages/C04PFHLL7/">Scotch.io</a></li>

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
 <li><a href="https://nativescriptcommunity.slack.com/">NativeScript</a></li>
 <li><a href="https://node-js.slack.com/messages/C3910A78T/">Node.JS</a></li>
 <li><a href="https://pythondev.slack.com/messages/C07EFBK3R/">Python developers</a></li>
+<li><a href="https://www.reactiflux.com/">Reactiflux</a></li>
 <li><a href="https://reactjsnews.slack.com/messages/C044HMK8N/">ReactJS</a></li>
 <li><a href="https://rubydevelopers.slack.com/">Ruby Developers</a></li>
 <li><a href="https://rubyonrails-link.slack.com/">Ruby on Rails</a></li>


### PR DESCRIPTION
Thanks for doing this @ladyleet !!

Reactiflux used to be on Slack but we got too big and had to leave. We are on discord now. So is Reason's community (https://discordapp.com/invite/reasonml).

I know this is a list of slack channel's... any chance we can still be added to the list?