### PR TITLE
Added Indy Hackers for Indiana

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In Illinois, Indiana, Iowa, Kansas, Michigan, Minnesota, Missouri, Nebraska, Nor
 
 *   IA - [Des Moines Web Collective](http://dsmwebcollective.com/)
 *   IL - [Chicago Tech](https://chicago-tech.slack.com/messages/C08UMGS7K/)
+*   IN - [Indy Hackers](https://indyhackers.slack.com)
 *   MI - [Startup Lansing](https://charlestontechslack.slack.com/messages/C070AT2P5/) in St.Louis
 *   MO - [STL Tech](https://stl-tech.slack.com/)
 *   OH - in Ohio there are several channels:


### PR DESCRIPTION
Added Indy Hackers for Indiana, an Indianapolis-based community helping organize events and jobs for programmers: https://indyhackers.slack.com/

They also have a site here: http://www.indyhackers.org/