### PR TITLE
Edit link and add new slacks to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Below are some other interesting Slack channels for different technologies and p
 
 *   [Chromium Dev](https://chromiumdev-slack.herokuapp.com/)
 *   [Firebase](https://firebase-community.appspot.com/)
+*   [MongoDB](https://community-slack.mongodb.com/)
 *   [Node.JS](https://node-js.slack.com/messages/C3910A78T/)
 *   [Progressive Web Apps (PWAs)](https://bit.ly/join-pwa-slack)
 *   [Polymer](https://polymer-slack.herokuapp.com/)
@@ -231,7 +232,8 @@ Below are some other interesting Slack channels for different technologies and p
 
 ## Women
 
-*   [Women in Tech](https://womenintech.slack.com/)
+*   [Women in Tech (WITchat)](http://witchat.github.io/)
+*   [Ladies of WordPress](https://ladiesofwp.slack.com)
 
 ## Misc Interest
 
@@ -248,6 +250,7 @@ Below are some other interesting Slack channels for different technologies and p
 *   [ReasonML](https://discordapp.com/invite/reasonml)
 *   [GravCMS](https://getgrav.org/slack)
 *   [PyroCMS](https://pyrocms.com/slack)
+*   [We are Developer Evangelist and YOU CAN TOO](http://evangelistcollective.github.io)
 
 ## Resources
 


### PR DESCRIPTION
- Edit Women in Tech (WITchat) slack sign-up link
- Add MongoDB slack to Technologies
- Add Ladies of WordPress slack to Women
- Add Dev Evangelist slack to Community Groups