### PR TITLE
remove 757dev slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Join these local Slack channels in Alabama, Arkansas, Florida, Georgia, Kentucky
 *   TN - [MTF Slack](http://slack.memphistechnology.org/)
 *   TN - [NashDev](http://nashdev.com/)
 *   TN - [KnoxDevs](http://knoxdevs-slackin.herokuapp.com/)
-*   VA - [757 Dev](http://757dev.org)
 
 ### The Southwest
 


### PR DESCRIPTION
We've seen a huge increase in the amount of spam in our slack since getting added to this list and would like to be removed.