### PR TITLE
Add Hampton Roads 757dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Join these local Slack channels in Alabama, Arkansas, Florida, Georgia, Kentucky
 *   TN - [KnoxDevs](http://knoxdevs-slackin.herokuapp.com/)
 *   VA - **in Virginia we have:**
     * [NRVDev](https://nrvdev.slack.org)
+    * [757dev](https://slackin757dev.herokuapp.com/)
 
 ### The Southwest
 


### PR DESCRIPTION
This commit adds the slack URL for the 757 (Hampton Roads) dev group.