### PR TITLE
removed space to fix Markdown formatting break

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In Illinois, Indiana, Iowa, Kansas, Michigan, Minnesota, Missouri, Nebraska, Nor
     *    [Chicago Tech](http://www.chicagotechslack.com/)
     *    [AWS Chicago](http://slack.chicagoaws.com/)
 *   IN - [Indy Hackers](http://indyhackers-slack.herokuapp.com/)
-*   KY - [Louisville.io] (http://louisville.io) & (http://louisville.slack.com)
+*   KY - [Louisville.io](http://louisville.io) & (http://louisville.slack.com)
 *   MI - [Startup Lansing](http://startuplansing.org/join-slack/) in St.Louis
 *   MN - [MSPTech](http://www.msptech.online/)
     *	 [Twin Cities Chaos Engineering Community](http://twincities-chaosengr.slack.com)


### PR DESCRIPTION
Lousiville meetup had a space between the `]` and `(` that caused the Markdown link to not be parsed as such.