### PR TITLE
Add the CodeBuddies Slack to `General Dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Below are some other interesting Slack channels for different technologies and p
 *   [Front End Web Developer](https://frontenddevelopers.slack.com) - Invites at http://frontenddevelopers.org/
 *   [Mr Frontend](https://mr-frontend-slack-invite.herokuapp.com/)
 *   [TechMasters](https://techmasters.chat/)
+*   [CodeBuddies](https://codebuddies.org/slack)
 
 ## General Testing & QA
 


### PR DESCRIPTION
Added CodeBuddies: a global community of code learners who help each other through conversations on Slack and peer-to-peer organized study groups and virtual hangouts.

This project is free, not-for-profit, transparent on Open Collective,  open-sourced, and powered by a fantastic team of core volunteer contributors.