### PR TITLE
Update Michigan

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ In Illinois, Indiana, Iowa, Kansas, Michigan, Minnesota, Missouri, Nebraska, Nor
     *    [AWS Chicago](http://slack.chicagoaws.com/)
 *   IN - [Indy Hackers](http://indyhackers-slack.herokuapp.com/)
 *   KY - [Louisville.io] (http://louisville.io) & (http://louisville.slack.com)
-*   MI - [Startup Lansing](http://startuplansing.org/join-slack/) in St.Louis
+*   MI - **In Michigan there are seval amazing channels:**
+    *    [Startup Lansing](http://startuplansing.org/join-slack/) in St.Louis
+    *    [Detroit Speakers in Tech](https://tinyurl.com/Join-DSIT-Slack) in Detroit area
 *   MN - [MSPTech](http://www.msptech.online/)
     *	 [Twin Cities Chaos Engineering Community](http://twincities-chaosengr.slack.com)
 *   MO - [STL Tech](https://stltech.herokuapp.com/)


### PR DESCRIPTION
Add Michigan as a heading with several links, Update Michigan to include Detroit Speakers in Tech