### PR TITLE
Add SacTech meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ From Alaska, Hawaii and Washington down to California there are several local ch
 *   CA - **California groups:**
     *   [Los Angeles Scala Users Group](https://lascalausers.slack.com/)
     *   [Santa Barbara Tech Co-op](https://sbtechcoop.slack.com/)
+    *   [Sacramento Javascript Meetup](https://sac-tech.herokuapp.com/)
 *   CO - **in Colorado there are several channels:**
     *   [Denver Devs](https://denverdevs.org/)
     *   [Tech Friends](https://www.gettechfriends.com/)


### PR DESCRIPTION
Added the Sacramento Javascript Meetup/SacTech slack to the list

Am unsure for more info, but this URL also exists:
https://www.meetup.com/The-Sacramento-Javascript-Meetup/messages/boards/thread/48998741