### PR TITLE
Added Western North Carolina Slack groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Join these local Slack channels in Alabama, Arkansas, Florida, Georgia, Kentucky
 *   NC
     * [Charlotte Devs](https://slack.charlottedevs.com/)
     * [Triangle Devs](https://triangle-devs-slack-inviter.herokuapp.com/)
+    * [WNC Tech](https://avltech.herokuapp.com)
+    * [Asheville Coders League](http://slack.avlcoders.org/)
 *   SC - [Charleston Tech](https://charlestontechslack.herokuapp.com/)
 *   TN
 	* [Chadev](https://chadev.com) - Chattanooga


### PR DESCRIPTION
Added two Slack groups from Western North Carolina: Asheville Coders League Slack and WNC Tech Slack