### PR TITLE
add Open Seattle for Washington

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ From Alaska, Hawaii and Washington down to California there are several local ch
 *   UT - [Utah Ruby User Group](http://urug.herokuapp.com/)
 *   WA - **in Washington there are several channels:**
     *   [Angular Seattle](https://angular-seattle.slack.com)
+    *   [Open Seattle](https://openseattle.slack.com)
     *   [Seattle Designers](https://seattledesigners.slack.com)
     *   [Seattle.rb](https://seattlerbslack.herokuapp.com/)
     *   [Seattle JS Hackers](https://seattlejshackers.slack.com)


### PR DESCRIPTION
Added the slack workspace of the Open Seattle org.
Details (including sign-up link): https://openseattle.org/slack/