### PR TITLE
Remove duplicate `Security` category

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,11 +389,6 @@ Below are some other interesting Slack channels for different technologies and p
 *   [TechMasters](https://techmasters.chat/)
 *   [CodeBuddies](https://codebuddies.org/slack)
 
-## Security
-
-*   [Node.js Security WG](https://nodejs-security-wg.herokuapp.com/)
-
-
 ## General Testing & QA
 
 *   [A/B Testing - modern testing, data science, agile development](https://oneofthethree.slack.com/) & (http://moderntesting.org)


### PR DESCRIPTION
For some reason the `Security` category exists twice:

1. with `Node.js Security WG` and `The Secure Developer`
2. with only `Node.js Security WG`

I removed the duplicate version.