### PR TITLE
added LeedsDevs (UK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ From Alaska, Hawaii and Washington down to California there are several local ch
 
 *   London - [Front End London](http://frontendlondon-slack.herokuapp.com/)
 *   Manchester - [mcrtech](http://mcrtech-slack.herokuapp.com/) - wide variety of topics, for Manchester and the North-West
+*   Leeds - [LeedsDevs](https://www.leedsdevs.co.uk) - all devs and tech professionals in the Leeds/Yorkshire area are welcome
 
 ### 🇺🇦 Ukraine
 


### PR DESCRIPTION
New UK Slack workspace added for LeedsDevs - all devs and tech professionals in the Leeds/Yorkshire area are welcome.