### PR TITLE
fix: Chicago tech group links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ In Illinois, Indiana, Iowa, Kansas, Michigan, Minnesota, Missouri, Nebraska, Nor
   - [Startup Iowa](http://www.startupiowachat.com/)
   - [WordPress Des Moines](http://wpdsm.org/)(http://wordpressdsm.herokuapp.com/)
 - IL - **In Illinois there are several channels:**
-  - [Chicago Tech](http://www.chicagotechslack.com/)
+  - [Chicago Tech](http://www.chitechdiversity.com/)
   - [AWS Chicago](http://slack.chicagoaws.com/)
   - [ChiPy (Chicago Python User Group)](https://www.chipy.org/)(https://joinchipyslack.herokuapp.com/)
   - [Chicago Tech Diversity Initiative](chitechdiversity.slack.com)


### PR DESCRIPTION
closes #264 

# Add a Slack Group

- [ ] Suggestion is not a duplicate
- [ ] Suggestion is placed in the proper country according the slack channel’s demographic or if it’s a general channel, it’s placed in the appropriate category
- [ ] Name and link are accurate
- [ ] Brief description of the channel is accurate and properly typed

# Remove a Slack Group

- [ ] Name of Slack group is present
- [ ] Reason for requesting removal is present
