### PR TITLE
Added a markdown link checker

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import re
+import requests
+import subprocess
+import sys
+import os
+
+def check_links(file_path):
+    with open(file_path, 'r') as file:
+        content = file.read()
+
+    # Regex to find Markdown links
+    markdown_link_regex = r'\[([^\]]+)\]\((http[s]?://[^)]+)\)'
+    links = re.findall(markdown_link_regex, content)
+
+    broken_links = []
+    for label, url in links:
+        try:
+            response = requests.head(url, allow_redirects=True, timeout=10)
+            if response.status_code >= 400:
+                broken_links.append((label, url))
+        except requests.RequestException:
+            broken_links.append((label, url))
+
+    return broken_links
+
+def get_markdown_files():
+    """Returns a list of Markdown files to check in both local and CI/CD environments."""
+    if os.getenv("GITHUB_ACTIONS"):  # Running in GitHub Actions
+        result = subprocess.run(
+            ["git", "ls-files", "*.md"], capture_output=True, text=True
+        )
+        return result.stdout.split()
+    else:  # Running as a pre-commit hook locally
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"], capture_output=True, text=True
+        )
+        return [f for f in result.stdout.split() if f.endswith('.md')]
+
+def main():
+    markdown_files = get_markdown_files()
+
+    exit_code = 0
+    for file_path in markdown_files:
+        broken_links = check_links(file_path)
+        if broken_links:
+            print(f"❌ Error: Broken links found in {file_path}:")
+            for label, url in broken_links:
+                print(f"  - [{label}]({url})")
+            exit_code = 1
+
+    sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,27 @@
+name: Markdown Link Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master  # Adjust based on your default branch
+
+jobs:
+  link-check:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install Dependencies
+        run: pip install requests
+
+      - name: Run Markdown Link Checker
+        run: python .github/hooks/pre-commit


### PR DESCRIPTION
This will allow all the links in the markdown text to be checked before a merge or commit. 
It can run as a pre-commit hook locally and as a PR merge check. 

## This should: 
1. Run the script inside a containerized GitHub Actions environment.
2. Checks for broken links in .md files.
3. Fails the PR if broken links are found.

## Example output: 
If a link is broken in README.md: 
```
❌ Error: Broken links found in README.md:
  - [Docs](https://example.com/invalid-page)
```


## To set this up as a GitHub status check on PR merge: 
Add a GitHub Status Check
If you want GitHub to block merging until the check passes:
1. Go to Repository Settings → Branch Protection Rules.
2. Add "Markdown Link Check" as a required check.

